### PR TITLE
Add curl install

### DIFF
--- a/src/react/commands/ExecuteCommand.ts
+++ b/src/react/commands/ExecuteCommand.ts
@@ -19,7 +19,7 @@ const executeCommandAsync = async (cmd: string): Promise<any> => {
     child.once('exit', function (code) {
       resolve(code);
     });
-
+    
     child.on('error', function (err) {
       reject(err);
     });
@@ -36,7 +36,7 @@ const executeCommandSync = (cmd: string): number => {
   try {
     execSync(cmd);
     return 0;
-  }
+  } 
   catch (error) {
     // TODO: more robust error handling
     error.status;
@@ -53,7 +53,7 @@ const executeCommandSyncReturnStdout = (cmd: string): string => {
 
   try {
     return execSync(cmd).toString();
-  }
+  } 
   catch (error) {
     // TODO: more robust error handling
     error.status;
@@ -77,7 +77,7 @@ const executeCommandWithPromptsAsync = (cmd: string, args: string[], responses: 
     child.once('exit', function (code) {
       resolve(code);
     });
-
+    
     child.on('error', function (err) {
       reject(err);
     });

--- a/src/react/commands/ExecuteCommand.ts
+++ b/src/react/commands/ExecuteCommand.ts
@@ -19,7 +19,7 @@ const executeCommandAsync = async (cmd: string): Promise<any> => {
     child.once('exit', function (code) {
       resolve(code);
     });
-    
+
     child.on('error', function (err) {
       reject(err);
     });
@@ -36,7 +36,7 @@ const executeCommandSync = (cmd: string): number => {
   try {
     execSync(cmd);
     return 0;
-  } 
+  }
   catch (error) {
     // TODO: more robust error handling
     error.status;
@@ -53,7 +53,7 @@ const executeCommandSyncReturnStdout = (cmd: string): string => {
 
   try {
     return execSync(cmd).toString();
-  } 
+  }
   catch (error) {
     // TODO: more robust error handling
     error.status;
@@ -77,7 +77,7 @@ const executeCommandWithPromptsAsync = (cmd: string, args: string[], responses: 
     child.once('exit', function (code) {
       resolve(code);
     });
-    
+
     child.on('error', function (err) {
       reject(err);
     });

--- a/src/react/commands/RocketPool.ts
+++ b/src/react/commands/RocketPool.ts
@@ -37,6 +37,15 @@ const getEth2ClientName = (): string => {
   }
 }
 
+const installCurl = (password: string, callback: Callback) => {
+  const curlRc = executeCommandSync("echo " + password + " | sudo -S apt update -y && sudo -S apt install curl -y");
+  if (curlRc != 0) {
+    console.log("curl failed to install");
+    callback(false);
+    return;
+  }
+}
+
 const installAndStartRocketPool = async (password: string, callback: Callback) => {
   const cliRc = executeCommandSync(ROCKET_POOL_INSTALL_COMMAND);
   if (cliRc != 0) {
@@ -174,6 +183,7 @@ const dockerContainerStatus = async (containerName: string, nodeStatusCallback: 
 
 export {
   getEth2ClientName,
+  installCurl,
   installAndStartRocketPool,
   isRocketPoolInstalled,
   openEth1Logs,

--- a/src/react/pages/Installing.tsx
+++ b/src/react/pages/Installing.tsx
@@ -10,7 +10,8 @@ import React, { useState } from "react";
 import styled, { keyframes } from "styled-components";
 
 import { History } from "history";
-import { installAndStartRocketPool } from "../commands/RocketPool";
+import { installAndStartRocketPool, installCurl } from "../commands/RocketPool";
+import { which } from "../commands/BashUtils";
 
 const ENTER_KEYCODE = 13;
 
@@ -136,7 +137,7 @@ const Installing = ({ history }: {history: History}) => {
     var code = event.keyCode || event.which;
     if(code === ENTER_KEYCODE) {
         handleSubmitPassword();
-    } 
+    }
   }
 
   const handleSubmitPassword = () => {
@@ -145,16 +146,34 @@ const Installing = ({ history }: {history: History}) => {
 
     setInstallInProgress(true);
 
+    // install curl if not there
+    if (which("curl")) {
+      console.log("curl installed, continuing to RocketPool installation...");
+    } else {
+      console.log("curl not installed, installing that now...");
+      installCurl(password, curlInstallCallback);
+    }
+
     // Without this setTimeout, there was a pause before the screen would update saying Installing...
     setTimeout(() => {
       installAndStartRocketPool(password, installCallback);
     }, 2000);
   }
 
+  const curlInstallCallback = (success: boolean) => {
+    if (success) {
+      console.log("curl installed");
+      history.push("/installing");
+    } else {
+      console.log("curl install failed");
+      history.push("/installfailed");
+    }
+  }
+
   const installCallback = (success: boolean) => {
     if (success) {
       console.log("install succeeded")
-      
+
       // wait 5 seconds before redirecting to make sure everythings up
       setTimeout(() => {
         history.push('/status');

--- a/src/react/pages/SystemCheck.tsx
+++ b/src/react/pages/SystemCheck.tsx
@@ -8,7 +8,6 @@ import React, { useEffect, useState } from "react";
 import Footer from "../components/Footer";
 import { isRocketPoolInstalled } from "../commands/RocketPool";
 import styled from "styled-components";
-import { which } from "../commands/BashUtils";
 
 const Container = styled.div`
   display: flex;
@@ -53,7 +52,6 @@ const SystemCheck = () => {
   const [showAdvanced, setShowAdvanced] = useState(false);
 
   const [arbitraryTest, setArbitraryTest] = useState(true);
-  const [curlInstalled, setCurlInstalled] = useState(false);
   const [rocketPoolInstalled, setRocketPoolInstalled] = useState(false);
   const [systemStatus, setSystemStatus] = useState(false);
 
@@ -64,11 +62,10 @@ const SystemCheck = () => {
   useEffect(() => {
     setSystemStatus(
       arbitraryTest &&
-      curlInstalled &&
       !rocketPoolInstalled
     );
-  }, [arbitraryTest, curlInstalled, rocketPoolInstalled]);
-  
+  }, [arbitraryTest, rocketPoolInstalled]);
+
   const runSystemCheck = () => {
     // TODO: do more validation here
     // TODO: check OS
@@ -76,7 +73,6 @@ const SystemCheck = () => {
     // TODO: check for anything that looks like an already running eth1/2 node
     // TODO: check ports
     setRocketPoolInstalled(isRocketPoolInstalled());
-    setCurlInstalled(which("curl"));
     setArbitraryTest(true);
 
     // TODO: add instructions/links for install/fix if a test fails
@@ -111,10 +107,6 @@ const SystemCheck = () => {
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>curl installed</td>
-            <td>{resultToIcon(curlInstalled)}</td>
-          </tr>
           <tr>
             <td>Rocket Pool <i>not</i> installed</td>
             <td>{resultToIcon(!rocketPoolInstalled)}</td>


### PR DESCRIPTION
Cleaned up curl checks on SystemCheck page, since its no longer required nor  a show stopper.  I added curl install on Installing page along with its components.  Idea here was to clean up as well as insert new behavior.  

One thing is that needs to be added, when installing curl the screen does not change until curl has been installed.  This is because its a sync execute and will not push a new screen until the command is run. Open to suggestions on how to handle that as it is likely confusing for users when they hit continue and nothing happens.